### PR TITLE
Fix chunk index calculation in WorldLoader

### DIFF
--- a/src/io/worldLoader.js
+++ b/src/io/worldLoader.js
@@ -49,9 +49,10 @@ export class WorldLoader {
   getChunkDataFromRegionBuffer(buffer, chunkX, chunkY, chunkZ) {
     const dv = new DataView(buffer);
     const headerSize = 11;
+    const GRID = REGION_SCHEMA.GRID;
 
-    // Ordine di indicizzazione come nel writer: z + GRID*(y + GRID*x)
-    const idx = chunkX + REGION_SCHEMA.GRID * (chunkY + REGION_SCHEMA.GRID * chunkZ);
+    // Calcola l'indice con ordine X→Y→Z
+    const idx = ((chunkX * GRID) + chunkY) * GRID + chunkZ;
     const off = headerSize + idx * 5;
 
     // offset a 24 bit (big-endian)
@@ -71,8 +72,8 @@ export class WorldLoader {
     const headerSize = 11;
     const GRID = REGION_SCHEMA.GRID;
 
-    // CORREZIONE: Ordine di indicizzazione per X-maggiore
-    const idx = chunkX + GRID * (chunkY + GRID * chunkZ);
+    // Calcola l'indice con ordine X→Y→Z
+    const idx = ((chunkX * GRID) + chunkY) * GRID + chunkZ;
     const off = headerSize + idx * 5;
 
     // offset a 24 bit


### PR DESCRIPTION
## Summary
- use ((chunkX * GRID) + chunkY) * GRID + chunkZ for chunk indexing in region buffers
- update comments to reflect new X→Y→Z order

## Testing
- `node -e 'import {generateRegionBuffer} from "./generator_structured.js";import {Region} from "./src/world/region.js";import {WorldLoader} from "./src/io/worldLoader.js";import {REGION_SCHEMA} from "./src/world/config.js";const buf=generateRegionBuffer(0,0,0);const region=Region.fromBuffer(new Uint8Array(buf),{schema:REGION_SCHEMA});const wl=new WorldLoader();const GRID=REGION_SCHEMA.GRID;let mismatch=[];for(let x=0;x<GRID;x++)for(let y=0;y<GRID;y++)for(let z=0;z<GRID;z++){const chunk1=region.getChunk(x,y,z).toCoreData();const chunk2=wl.getChunkDataFromRegionBuffer(buf,x,y,z);if(!Buffer.from(chunk1).equals(Buffer.from(chunk2)))mismatch.push([x,y,z]);}console.log("mismatch count",mismatch.length);'`


------
https://chatgpt.com/codex/tasks/task_e_68bd9780c99c8323b1af320dade1cb00