### PR TITLE
Refactor chunk loop orientation in chunkManager

### DIFF
--- a/src/world/chunkManager.js
+++ b/src/world/chunkManager.js
@@ -423,18 +423,20 @@ export class ChunkManager {
                   const startY = ry * REGION_SCHEMA.REGION_SPAN + cy * REGION_SCHEMA.CHUNK_SIZE;
                   const startZ = rz * REGION_SCHEMA.REGION_SPAN + cz * REGION_SCHEMA.CHUNK_SIZE;
 
-                  let k = 0;
-                  // CORREZIONE: Ordine dei loop per allinearsi al generatore (x, y, z)
-                  for (let x = 0; x < REGION_SCHEMA.CHUNK_SIZE; x++) {
-                      for (let y = 0; y < REGION_SCHEMA.CHUNK_SIZE; y++) {
-                          for (let z = 0; z < REGION_SCHEMA.CHUNK_SIZE; z++) {
+                  // Riorganizzati i cicli per iterare z -> y -> x e calcolare
+                  // manualmente l'indice del voxel nel chunk di origine
+                  const CHUNK_SIZE = REGION_SCHEMA.CHUNK_SIZE;
+                  for (let z = 0; z < CHUNK_SIZE; z++) {
+                      for (let y = 0; y < CHUNK_SIZE; y++) {
+                          for (let x = 0; x < CHUNK_SIZE; x++) {
                               const destX = startX + x;
                               const destY = startY + y;
                               const destZ = startZ + z;
-                              
+
                               const destOffset = destX + destY * WINDOW_VOXEL_SPAN + destZ * WINDOW_VOXEL_SPAN * WINDOW_VOXEL_SPAN;
-                              
-                              this.voxelWindow[destOffset] = chunkData[k++];
+                              const srcIndex = x + CHUNK_SIZE * (y + CHUNK_SIZE * z);
+
+                              this.voxelWindow[destOffset] = chunkData[srcIndex];
                           }
                       }
                   }


### PR DESCRIPTION
## Summary
- Rework `onRegionDataReady` loops to iterate by `z`, `y`, `x` and compute source index directly.
- Ensures copied voxel data matches generator orientation.

## Testing
- `node --input-type=module <<'NODE'\nconst CHUNK_SIZE = 4;\nconst chunkData = new Uint8Array(CHUNK_SIZE**3);\nfor (let z=0; z<CHUNK_SIZE; z++)\n for (let y=0; y<CHUNK_SIZE; y++)\n  for (let x=0; x<CHUNK_SIZE; x++) chunkData[x + CHUNK_SIZE*(y + CHUNK_SIZE*z)] = 100*z + 10*y + x;\nconst WINDOW_VOXEL_SPAN = CHUNK_SIZE;\nconst voxelWindow = new Uint8Array(CHUNK_SIZE**3);\nfor (let z = 0; z < CHUNK_SIZE; z++)\n for (let y = 0; y < CHUNK_SIZE; y++)\n  for (let x = 0; x < CHUNK_SIZE; x++) {\n    const destX = x, destY = y, destZ = z;\n    const destOffset = destX + destY * WINDOW_VOXEL_SPAN + destZ * WINDOW_VOXEL_SPAN * WINDOW_VOXEL_SPAN;\n    const srcIndex = x + CHUNK_SIZE*(y + CHUNK_SIZE*z);\n    voxelWindow[destOffset] = chunkData[srcIndex];\n  }\nconsole.log(Array.from(voxelWindow.slice(0, 20)));\nNODE`
- `node --input-type=module <<'NODE'\nimport fs from 'fs';\nimport { verifyGeneratedRegion } from './validate_region.js';\nconst buffer = fs.readFileSync('./regions/r.0.0.0.voxl');\nconst result = verifyGeneratedRegion(buffer, 'r.0.0.0.voxl');\nconsole.log(result);\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ca6028483239e71bfb71ba13ac8