### PR TITLE
Refactor voxel window updates via worker

### DIFF
--- a/src/app/game.js
+++ b/src/app/game.js
@@ -15,7 +15,7 @@ export class Game {
     this.player = this.scene.activeCamera;
 
     this.chunkManager = new ChunkManager(this.scene, this.sceneInitializer.shadowGenerator);
-    this.worldLoader = new WorldLoader(this.chunkManager);
+    this.worldLoader = new WorldLoader();
 
     this.chunkManager.worldLoader = this.worldLoader;
 

--- a/src/io/worldLoader.js
+++ b/src/io/worldLoader.js
@@ -2,21 +2,14 @@
 import { REGION_SCHEMA } from '../world/config.js';
 
 export class WorldLoader {
-  constructor(chunkManager) {
+  constructor() {
     this.loadedRegions = new Set();
     this.regionsData = new Map(); // key -> ArrayBuffer
-    this.chunkManager = chunkManager; // Memorizza il riferimento al ChunkManager
   }
 
   async fetchAndStoreRegionData(regionX, regionY, regionZ) {
     const regionKey = `${regionX}_${regionY}_${regionZ}`;
     if (this.loadedRegions.has(regionKey)) {
-      // If the region is already loaded, ensure the ChunkManager still gets
-      // notified so it can reposition voxels in the window when the
-      // window origin changes.
-      if (this.chunkManager) {
-        this.chunkManager.onRegionDataReady(regionKey);
-      }
       return;
     }
 
@@ -40,18 +33,10 @@ export class WorldLoader {
         this.regionsData.set(regionKey, buffer);
       }
       
-      // Notifica il chunkManager quando i dati di QUESTA regione sono pronti
-      if (this.chunkManager) {
-        this.chunkManager.onRegionDataReady(regionKey);
-      }
-      
     } catch (err) {
       console.error(`Errore durante il caricamento della regione (${regionX}, ${regionY}, ${regionZ}):`, err);
       const emptyBuffer = new ArrayBuffer(0);
       this.regionsData.set(regionKey, emptyBuffer);
-      if (this.chunkManager) {
-        this.chunkManager.onRegionDataReady(regionKey);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- use `voxelWindowUpdater` worker to handle voxel window updates asynchronously
- gather region data and send to worker, updating `voxelWindow` on response
- remove obsolete `onRegionDataReady` callback and simplify world loader setup

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eb5e96288323b6df91e648375505